### PR TITLE
fix(map): map.once should emit only one time

### DIFF
--- a/packages/l7plot/__tests__/unit/core/map/event.test.ts
+++ b/packages/l7plot/__tests__/unit/core/map/event.test.ts
@@ -1,0 +1,25 @@
+import { Map, PlotOptions } from '../../../../src';
+import { createPlot } from '../../../helper/plot';
+
+describe('event listener', () => {
+  const map = createPlot(Map, {} as PlotOptions);
+  it('once', () => {
+    map.once('onceLoaded', function () {
+      console.log('onceLoaded');
+    });
+
+    expect(map.getEvents()['onceLoaded'][0].once).toBeTruthy();
+  });
+
+  it('on', () => {
+    const map = createPlot(Map, {} as PlotOptions);
+
+    map.on('onLoaded', function () {
+      console.log('onLoaded');
+    });
+
+    expect(map.getEvents()['onLoaded'][0].once).toBeFalsy();
+  });
+
+  setTimeout(() => map.destroy(), 0);
+});

--- a/packages/l7plot/src/core/map/index.ts
+++ b/packages/l7plot/src/core/map/index.ts
@@ -264,8 +264,8 @@ export abstract class Map<O extends MapOptions> extends EventEmitter {
   /**
    * 事件代理: 绑定事件
    */
-  public on(name: string, callback: (...args: any[]) => void) {
-    this.proxyEventHander('on', name, callback);
+  public on(name: string, callback: (...args: any[]) => void, realOnce?: boolean) {
+    this.proxyEventHander('on', name, callback, realOnce);
     return this;
   }
 
@@ -288,7 +288,12 @@ export abstract class Map<O extends MapOptions> extends EventEmitter {
   /**
    * 事件代理: 事件处理
    */
-  private proxyEventHander(type: 'on' | 'off' | 'once', name: string, callback: (...args: any[]) => void) {
+  private proxyEventHander(
+    type: 'on' | 'off' | 'once',
+    name: string,
+    callback: (...args: any[]) => void,
+    realOnce?: boolean
+  ) {
     const sceneEvent = SceneEventList.find((event) => event.adaptation === name);
     if (sceneEvent) {
       this.scene[type](sceneEvent.original, callback);
@@ -303,7 +308,7 @@ export abstract class Map<O extends MapOptions> extends EventEmitter {
         throw new Error(`No event name "${name}"`);
       }
     } else {
-      super[type](name, callback);
+      super[type](name, callback, realOnce);
     }
   }
 

--- a/packages/l7plot/src/core/map/index.ts
+++ b/packages/l7plot/src/core/map/index.ts
@@ -264,8 +264,8 @@ export abstract class Map<O extends MapOptions> extends EventEmitter {
   /**
    * 事件代理: 绑定事件
    */
-  public on(name: string, callback: (...args: any[]) => void, realOnce?: boolean) {
-    this.proxyEventHander('on', name, callback, realOnce);
+  public on(name: string, callback: (...args: any[]) => void, once?: boolean) {
+    this.proxyEventHander('on', name, callback, once);
     return this;
   }
 
@@ -292,7 +292,7 @@ export abstract class Map<O extends MapOptions> extends EventEmitter {
     type: 'on' | 'off' | 'once',
     name: string,
     callback: (...args: any[]) => void,
-    realOnce?: boolean
+    once?: boolean
   ) {
     const sceneEvent = SceneEventList.find((event) => event.adaptation === name);
     if (sceneEvent) {
@@ -308,7 +308,7 @@ export abstract class Map<O extends MapOptions> extends EventEmitter {
         throw new Error(`No event name "${name}"`);
       }
     } else {
-      super[type](name, callback, realOnce);
+      super[type](name, callback, once);
     }
   }
 


### PR DESCRIPTION
### PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [ ] fixed #0
- [x] add / modify test cases
- [ ] documents, demos

### Screenshot

| Before | After |
| ------ | ----- |
| ❌     | ✅    |
| <img width="492" alt="image" src="https://user-images.githubusercontent.com/19320239/200255747-173e84bf-eba5-47b2-bf46-d214e75b35ad.png"> | <img width="635" alt="image" src="https://user-images.githubusercontent.com/19320239/200255683-0a125c83-2699-42e9-b743-edbe6d5bd5bf.png"> |

### 简单介绍下这个 bug 的成因

Map 继承的是 EventEmitter，同时，Map 和 EventEmitter 类中都定义了 on/once 原型方法。假设 mapInstance 为 Map 实例，存在如下 Bug：

``` js
mapInstance.once('loaded', () => {})
const { loaded } = mapInstance.getEvents()
console.log(loaded[0].once === false)
// -->输出： true，此时 once 为 false； 按照预期行为，loaded[0].once 的值应该是 true，表示该回调只需触发一次
```

本来应该只触发一次的事件回调，实际上可能会触发多次。

### 修改的内容

1、 增加 event.test.js 测试用例，对事件监听的类型进行判断
2、修改 Map 事件订阅逻辑，使其能够正确监听 once 事件





